### PR TITLE
Use private IP address for etcd advertise URL

### DIFF
--- a/coreos/user-data.yml.erb
+++ b/coreos/user-data.yml.erb
@@ -6,7 +6,7 @@ coreos:
     reboot-strategy: off
   etcd2:
     discovery:
-    advertise-client-urls: "http://$public_ipv4:2379"
+    advertise-client-urls: "http://$private_ipv4:2379"
     initial-advertise-peer-urls: "http://$private_ipv4:2380"
     listen-client-urls: "http://0.0.0.0:2379"
     listen-peer-urls: "http://$private_ipv4:2380"


### PR DESCRIPTION
## WHY

Security Group blocks inbound traffic from Internet to 2379/tcp due to security reason.
It causes failure to build etcd cluster now.
## WHAT

Use private IP address for etcd advertise URL, to be used for clustering.
